### PR TITLE
Add tree traversal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,13 +31,12 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "berlin-core"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59971a182c17e7e3fce85b0be2a80b78a5fd77c35ae7057dca7af655ce8e3ab8"
 dependencies = [
  "ahash",
  "csv",
  "deunicode",
  "fst",
+ "indextree",
  "nom",
  "petgraph",
  "rayon",
@@ -229,6 +228,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "indextree"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c40411d0e5c63ef1323c3d09ce5ec6d84d71531e18daed0743fccea279d7deb6"
 
 [[package]]
 name = "indoc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "berlin-core"
-version = "0.2.2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2849e4ad4cb3ca4cf83f4b9effcfa64a66028c642663c000f0f7a458f0d38892"
 dependencies = [
  "ahash",
  "csv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Metin Akat", email = "metin.akat@flaxandteal.co.uk"},
     {name = "Phil Weir", email = "phil.weir@flaxandteal.co.uk"}
 ]
-version = "0.3.9"
+version = "0.3.10"
 description = "Identify locations and tag them with UN-LOCODEs and ISO-3166-2 subdivisions."
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/tests/test_berlin.py
+++ b/tests/test_berlin.py
@@ -23,7 +23,36 @@ def test_retrieve(db):
     assert list(loc.words) == ["abercarn"]
     assert loc.get_names() == ["abercarn"]
     assert loc.get_codes() == ["abc"]
-    assert loc.get_state() == "gb"
-    assert loc.get_subdiv() == "cay"
-    assert db.get_state_name(loc.get_state()) == "united kingdom of great britain and northern ireland"
-    assert db.get_subdiv_name(loc.get_state(), loc.get_subdiv()) == "caerphilly [caerffili gb-caf]"
+    assert loc.get_state_code() == "gb"
+    assert loc.get_subdiv_code() == "cay"
+    assert db.get_state_key(loc.get_state_code()) == "ISO-3166-1-gb"
+    assert db.get_subdiv_key(loc.get_state_code(), loc.get_subdiv_code()) == "ISO-3166-2-gb:cay"
+    assert loc.subdiv.id == "gb:cay"
+
+def test_retrieve_country(db):
+    loc = db.retrieve("ISO-3166-1-gb")
+    assert isinstance(loc, Location)
+    assert loc.key == "ISO-3166-1-gb"
+    assert loc.encoding == "ISO-3166-1"
+    assert loc.id == "gb"
+    assert sorted(loc.words) == ["britain", "great", "ireland", "kingdom", "northern", "united"]
+    assert loc.get_names() == ["united kingdom of great britain and northern ireland"]
+    assert loc.get_codes() == ["gb", "gbr", "uk"]
+    assert loc.get_state_code() == "gb"
+    assert loc.get_subdiv_code() is None
+    assert db.get_state_key(loc.get_state_code()) == "ISO-3166-1-gb"
+    assert loc.state.get_state_code() == "gb"
+    assert loc.subdiv is None
+
+def test_retrieve_country_children(db):
+    loc = db.retrieve("ISO-3166-1-gb")
+    assert len(loc.children) == 2
+    assert {child.key for child in loc.children} == {"ISO-3166-2-gb:cay", "ISO-3166-2-gb:abd"}
+
+    aberdeen = next(child for child in loc.children if child.key == "ISO-3166-2-gb:abd")
+    assert len(aberdeen.children) == 1
+
+    stonehaven = aberdeen.children[0]
+    assert stonehaven.get_names() == ["stonehaven"]
+
+    assert stonehaven.children == []


### PR DESCRIPTION
Allows navigation of tree by `.state` `.subdiv` and `.children` on Location objects.