### PR TITLE
Feature: add generic codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "berlin-core"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5864554135e7827a10d35a906c750c3e6b1c0204468c318fa0868cfb66a2b3"
+checksum = "30acbd9ab65bd2c97855c4d1a98523e4e8220298c02b1a6bc4f64f393890260f"
 dependencies = [
  "ahash",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.18.3", features = ["extension-module"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
-berlin-core = "0.2.4"
+berlin-core = "0.2.6"
 
 # Logging
 tracing = "0.1.29"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Metin Akat", email = "metin.akat@flaxandteal.co.uk"},
     {name = "Phil Weir", email = "phil.weir@flaxandteal.co.uk"}
 ]
-version = "0.3.13"
+version = "0.3.14"
 description = "Identify locations and tag them with UN-LOCODEs and ISO-3166-2 subdivisions."
 readme = "README.md"
 license = {file = "LICENSE.md"}

--- a/python/berlin/__init__.py
+++ b/python/berlin/__init__.py
@@ -4,4 +4,4 @@ from berlin._berlin import (
     Location as Location
 )
 
-__version__ = "0.3.12"
+__version__ = "0.3.14"

--- a/tests/data/test-codes.json
+++ b/tests/data/test-codes.json
@@ -27,17 +27,6 @@
       "continent": "EU"
     }
   },
-  "GB:ABC": {
-    "<c>": "ISO-3166-2",
-    "s": "<bln|ISO-3166-2#GB:ABC|\"Armagh, Banbridge and Craigavon\">",
-    "i": "GB:ABC",
-    "d": {
-      "name": "Armagh, Banbridge and Craigavon",
-      "supercode": "GB",
-      "subcode": "ABC",
-      "level": "[UNKNOWN]"
-    }
-  },
   "GB:ABD": {
     "<c>": "ISO-3166-2",
     "s": "<bln|ISO-3166-2#GB:ABD|\"Aberdeenshire\">",
@@ -46,6 +35,17 @@
       "name": "Aberdeenshire",
       "supercode": "GB",
       "subcode": "ABD",
+      "level": "council area"
+    }
+  },
+  "GB:ABC2": {
+    "<c>": "ISO-3166-2",
+    "s": "<bln|ISO-3166-2#GB:ABC|\"Armagh City, Banbridge and Craigavon\">",
+    "i": "GB:ABC",
+    "d": {
+      "name": "Armagh City, Banbridge and Craigavon",
+      "supercode": "GB",
+      "subcode": "ABC",
       "level": "council area"
     }
   },
@@ -193,6 +193,29 @@
       "supercode": "BG",
       "subcode": "02",
       "level": "region"
+    }
+  },
+  "my:1": {
+    "<c>": "MY-STANDARD",
+    "s": "<bln|MY-STANDARD#MY:1|\"My One\">",
+    "i": "my:1",
+    "d": {
+      "name": "My One1",
+      "supercode": "BG",
+      "subcode": "my-1",
+      "subdivision_code": "02",
+      "c": "54N 6W"
+    }
+  },
+  "my:2": {
+    "<c>": "MY-STANDARD",
+    "s": "<bln|MY-STANDARD#MY:2|\"My Two\">",
+    "i": "my:2",
+    "d": {
+      "name": "My Two2",
+      "supercode": "BG",
+      "subcode": "my-2",
+      "subdivision_code": "02"
     }
   }
 }

--- a/tests/test_berlin.py
+++ b/tests/test_berlin.py
@@ -88,3 +88,17 @@ def test_retrieve_country_children(db):
     assert stonehaven.get_names() == ["stonehaven"]
 
     assert stonehaven.children == []
+
+def test_search_for_generic_with_state(db):
+    for query in ("Dentists in Two2", "Dental Two2"):
+        state = "GB"
+        limit = 2
+        lev_distance = 2
+
+        result = db.query(query, limit, lev_distance, state=state)
+        assert len(result) == 1
+        loc = result[0]
+        assert loc.key == "MY-STANDARD-gb:my-2"
+        assert loc.encoding == "MY-STANDARD"
+        assert loc.id == "gb:my-2"
+        assert list(loc.words) == ["My Two2"]


### PR DESCRIPTION
This allows codes to be added to berlin's search that are not of a known type (Locode, IATA, etc.)